### PR TITLE
fix: drop support for the unmaintained node-scrypt module (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,6 @@ The displayname_ext parameter defines from which file the displayname of a user 
 apt-get install -yqq python-bcrypt
 python -c 'import bcrypt; print(bcrypt.hashpw(b"password", bcrypt.gensalt(rounds=10, prefix=b"2a")))'
 ```
-#### Scrypt:
-```Javascript
-var scrypt = require('scrypt');
-console.log(scrypt.kdfSync("password", scrypt.paramsSync(0.1)));
-```
 #### Argon2:
 ```Javascript
 var argon2 = require('argon2');

--- a/ep_hash_auth.js
+++ b/ep_hash_auth.js
@@ -12,7 +12,12 @@ const settings = require('ep_etherpad-lite/node/utils/Settings');
 const authorManager = require('ep_etherpad-lite/node/db/AuthorManager');
 const crypto = require('crypto');
 
-// npm install bcrypt/scrypt/argon2 (optional but recommended)
+// npm install bcrypt/argon2 (optional but recommended)
+//
+// Note: the `scrypt` npm module is deprecated and has not built against
+// modern Node.js for years (#10). If you still have scrypt-format hashes,
+// re-hash them with bcrypt or argon2 — both are still actively
+// maintained.
 const optionalRequire = (library, name, npmLibrary) => {
   try {
     return require(library);
@@ -25,7 +30,6 @@ const optionalRequire = (library, name, npmLibrary) => {
 };
 
 const bcrypt = optionalRequire('bcrypt', 'bcrypt', 'bcrypt');
-const scrypt = optionalRequire('scrypt', 'scrypt', 'scrypt');
 const argon2 = optionalRequire('argon2', 'argon2', 'argon2');
 
 // ocrypt-relevant options
@@ -83,15 +87,6 @@ const compareHashes = async (password, hash, callback) => {
     } else {
       console.log('Warning: Could not verify bcrypt hash due to missing dependency');
     }
-  } else if (scrypt) {
-    // This is a scrypt hash or a failed crypto hash
-    if (scrypt.verifyKdfSync(Buffer.from(hash, 'hex'), Buffer.from(password))) {
-      return callback('scrypt');
-    } else {
-      return callback(null);
-    }
-  } else {
-    console.log('Warning: Could not verify scrypt hash due to missing dependency');
   }
   return callback(null);
 };

--- a/static/tests/backend/specs/no_scrypt.js
+++ b/static/tests/backend/specs/no_scrypt.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+
+const pluginSrc = path.resolve(__dirname, '..', '..', '..', '..', 'ep_hash_auth.js');
+const readme = path.resolve(__dirname, '..', '..', '..', '..', 'README.md');
+
+describe(__filename, function () {
+  it('ep_hash_auth.js no longer references the unmaintained scrypt module (#10)', function () {
+    const src = fs.readFileSync(pluginSrc, 'utf8');
+    // The comment block explaining that scrypt was dropped is allowed; what
+    // we guard against is an `optionalRequire('scrypt', ...)` or any call
+    // into a `scrypt` variable that used to shadow the npm module.
+    assert(!/optionalRequire\(\s*['"]scrypt['"]/.test(src),
+        'should not attempt to optionalRequire the deprecated `scrypt` npm module');
+    assert(!/\bscrypt\s*\.\s*verifyKdfSync\b/.test(src),
+        'should not call into the removed scrypt.verifyKdfSync path');
+    assert(!/\bconst\s+scrypt\s*=/.test(src),
+        'should not bind a `scrypt` module variable');
+  });
+
+  it('README no longer documents the scrypt hash-generation recipe (#10)', function () {
+    const md = fs.readFileSync(readme, 'utf8');
+    assert(!/require\(['"]scrypt['"]\)/.test(md),
+        'README should not show the deprecated scrypt recipe');
+  });
+});


### PR DESCRIPTION
Fixes #10. The `scrypt` npm package hasn't been maintained in years and no longer builds against modern Node.js, so the `optionalRequire('scrypt', ...)` branch always logged a missing-dependency warning and was effectively dead code. Remove the whole scrypt path (plus the README recipe for generating scrypt hashes). Users with scrypt-format hashes should re-hash to bcrypt or argon2, both of which are still supported and actively maintained. Backend spec asserts the module and README no longer reference scrypt.