### PR TITLE
fix: trim trailing newlines from hash files so bcrypt match works (#8)

### DIFF
--- a/ep_hash_auth.js
+++ b/ep_hash_auth.js
@@ -125,7 +125,13 @@ exports.authenticate = (hook_name, context, cb) => {
               `Error: Failed authentication attempt for ${username}: no authentication found`);
           return cb([false]);
         } else {
-          compareHashes(password, contents, (hashType) => {
+          // Hash files produced with `echo "..." > .hash` or a text editor
+          // (vi, nano, …) almost always end with a trailing newline. Strip
+          // it before comparing; otherwise every bcrypt/scrypt/crypto check
+          // silently fails and users see cryptic "no such user" errors
+          // (#8). trim() also tolerates accidental leading whitespace.
+          const hashFromFile = contents.trim();
+          compareHashes(password, hashFromFile, (hashType) => {
             if (hashType) {
               console.log(`Log: Authenticated (${hashType}-file) ${username}`);
               // read displayname if available
@@ -135,7 +141,7 @@ exports.authenticate = (hook_name, context, cb) => {
                 if (err) {
                   console.log(`Log: Could not load displayname for ${username}`);
                 } else {
-                  displayname = contents;
+                  displayname = contents.trim();
                 }
                 settings.users[username] = {username, is_admin: hash_adm, displayname};
                 context.req.session.user = settings.users[username];


### PR DESCRIPTION
Fixes #8. Hash files created with `echo "..." > .hash` or vi/nano end with a trailing newline, and the plugin was feeding the raw contents into `compareHashes` — which always failed the match because "\$2a\$…hash\n" !== the computed hash. Users saw `no authentication found` log lines with no obvious cause and had to patch the source themselves to add `.trim()`.

Trim the file contents (both .hash and the optional .displayname). Same behaviour for already-clean files, plus tolerant of the overwhelmingly common trailing newline.