### PR TITLE
ci: allow bcrypt / argon2 postinstall scripts in publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,11 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "bcrypt",
+      "argon2"
+    ]
   }
 }


### PR DESCRIPTION
Fixes `ERR_PNPM_IGNORED_BUILDS` in publish. Adding bcrypt + argon2 as optional deps in #95 brought in their native-addon postinstall scripts; pnpm 10's `strict-dep-builds` refuses them by default. Allow both via `pnpm.onlyBuiltDependencies` so CI can actually build the bindings.