### PR TITLE
feat: add logout button for HTTP Basic auth (#50)

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -4,7 +4,10 @@
       "name": "ep_hash_auth",
       "hooks": {
         "authenticate": "ep_hash_auth/ep_hash_auth",
-        "handleMessage": "ep_hash_auth/ep_hash_auth"
+        "handleMessage": "ep_hash_auth/ep_hash_auth",
+        "expressCreateServer": "ep_hash_auth/ep_hash_auth",
+        "eejsBlock_userlist": "ep_hash_auth/ep_hash_auth",
+        "eejsBlock_scripts": "ep_hash_auth/ep_hash_auth"
       }
     }
   ]

--- a/ep_hash_auth.js
+++ b/ep_hash_auth.js
@@ -171,6 +171,50 @@ exports.authenticate = (hook_name, context, cb) => {
   } else { return cb([false]); }
 };
 
+// Path the client and server both use for the logout dance. Kept short so
+// curl-based logouts stay easy to type.
+const LOGOUT_PATH = '/ep_hash_auth/logout';
+
+// Logging out of HTTP Basic auth is a browser-quirk problem. Destroying
+// `req.session.user` is necessary but not sufficient — the browser keeps
+// re-sending the cached `Authorization` header on every subsequent request.
+// We do two things:
+//   1. Server returns 401 with a fresh `WWW-Authenticate` realm. This nudges
+//      Firefox/Safari to drop their cred cache for the original realm.
+//   2. Client first calls /logout with a deliberately wrong Authorization
+//      header, which overwrites Chrome's cred cache for this origin.
+// The combination is what works cross-browser; either one alone leaves at
+// least one major browser still authenticated.
+exports.expressCreateServer = (hookName, {app}, cb) => {
+  app.get(LOGOUT_PATH, (req, res) => {
+    if (req.session && req.session.user) delete req.session.user;
+    // Use a per-request realm so the browser sees this as a *different*
+    // protection space than the one it cached creds for.
+    res.set('WWW-Authenticate', `Basic realm="ep_hash_auth-logout-${Date.now()}"`);
+    res.status(401).send(
+        '<!doctype html><meta charset="utf-8"><title>Logged out</title>' +
+        '<p>You have been logged out. ' +
+        '<a href="/">Return to the home page</a>.</p>');
+  });
+  return cb();
+};
+
+exports.eejsBlock_userlist = (hookName, args, cb) => {
+  args.content +=
+      '<div id="ep_hash_auth_logout">' +
+      '<button id="ep_hash_auth_logout_btn" class="btn btn-default" ' +
+      'data-l10n-id="ep_hash_auth.logout" ' +
+      'aria-label="Log out of this Etherpad session">Log out</button>' +
+      '</div>';
+  return cb();
+};
+
+exports.eejsBlock_scripts = (hookName, args, cb) => {
+  args.content +=
+      '<script src="/static/plugins/ep_hash_auth/static/js/logout.js"></script>';
+  return cb();
+};
+
 exports.handleMessage = (hook_name, context, cb) => {
   // skip if we don't have any information to set
   const session = context.client.client.request.session;

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,3 @@
+{
+  "ep_hash_auth.logout": "Log out"
+}

--- a/static/js/logout.js
+++ b/static/js/logout.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// Logging out of HTTP Basic auth requires evicting the browser's cached
+// `Authorization` header. Server-side session destruction is not enough —
+// the browser would just re-authenticate on the next request.
+//
+// The cross-browser dance:
+//   1. Send a fetch to /ep_hash_auth/logout with a deliberately invalid
+//      Authorization header. Chrome treats the new (failing) credentials as
+//      replacing the cached good ones for this origin.
+//   2. The server returns 401 with a per-request realm, which nudges
+//      Firefox/Safari to drop their cred cache for the original realm.
+//   3. Redirect to "/" so the user lands somewhere sensible. The next
+//      request to a protected resource will trigger a fresh Basic prompt.
+
+(() => {
+  const LOGOUT_PATH = '/ep_hash_auth/logout';
+
+  const doLogout = () => {
+    const poison = fetch(LOGOUT_PATH, {
+      method: 'GET',
+      credentials: 'include',
+      headers: {Authorization: `Basic ${btoa('logout:logout')}`},
+      cache: 'no-store',
+    }).catch(() => { /* network failures still drop us at "/" below */ });
+
+    poison.finally(() => {
+      window.location.href = '/';
+    });
+  };
+
+  const bind = () => {
+    const btn = document.getElementById('ep_hash_auth_logout_btn');
+    if (!btn || btn.dataset.epHashAuthBound === '1') return;
+    btn.dataset.epHashAuthBound = '1';
+    btn.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      doLogout();
+    });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bind);
+  } else {
+    bind();
+  }
+})();

--- a/static/tests/backend/specs/logout.js
+++ b/static/tests/backend/specs/logout.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const assert = require('assert').strict;
+const path = require('path');
+// express + supertest are provided by Etherpad core's node_modules at test
+// time; eslint can't see them from this plugin's source tree.
+const express = require('express'); // eslint-disable-line n/no-missing-require
+const supertest = require('supertest'); // eslint-disable-line n/no-missing-require
+
+const pluginPath = path.resolve(__dirname, '..', '..', '..', '..', 'ep_hash_auth.js');
+
+const buildApp = (plugin, sessionRef) => {
+  const app = express();
+  // Stub session middleware so the plugin can mutate `req.session.user`.
+  app.use((req, res, next) => {
+    req.session = sessionRef;
+    next();
+  });
+  return new Promise((resolve, reject) => {
+    plugin.expressCreateServer('expressCreateServer', {app}, (err) => {
+      if (err) return reject(err);
+      resolve(app);
+    });
+  });
+};
+
+describe('ep_hash_auth /logout endpoint', function () {
+  let plugin;
+  let session;
+  let agent;
+
+  // eslint-disable-next-line mocha/no-synchronous-tests
+  before(async function () {
+    delete require.cache[require.resolve(pluginPath)];
+    plugin = require(pluginPath);
+    session = {user: {username: 'alice', is_admin: false}};
+    const app = await buildApp(plugin, session);
+    agent = supertest(app);
+  });
+
+  it('returns 401 so the browser drops cached Basic creds', async function () {
+    const res = await agent.get('/ep_hash_auth/logout');
+    assert.equal(res.status, 401);
+  });
+
+  it('sets a fresh WWW-Authenticate realm distinct from the auth realm', async function () {
+    const res = await agent.get('/ep_hash_auth/logout');
+    assert.match(res.headers['www-authenticate'] || '', /^Basic realm="ep_hash_auth-logout-/);
+  });
+
+  it('clears req.session.user', async function () {
+    session.user = {username: 'alice', is_admin: false};
+    await agent.get('/ep_hash_auth/logout');
+    assert.equal(session.user, undefined);
+  });
+
+  it('returns an HTML body with a link back to /', async function () {
+    const res = await agent.get('/ep_hash_auth/logout');
+    assert.match(res.text, /<a href="\/">/);
+  });
+
+  it('does not throw when there is no session.user to clear', async function () {
+    const emptySession = {};
+    const app = await buildApp(plugin, emptySession);
+    const res = await supertest(app).get('/ep_hash_auth/logout');
+    assert.equal(res.status, 401);
+  });
+});
+
+describe('ep_hash_auth eejs blocks', function () {
+  let plugin;
+
+  // eslint-disable-next-line mocha/no-synchronous-tests
+  before(function () {
+    delete require.cache[require.resolve(pluginPath)];
+    plugin = require(pluginPath);
+  });
+
+  const callBlock = (name) => new Promise((resolve) => {
+    const args = {content: ''};
+    plugin[name](name, args, () => resolve(args.content));
+  });
+
+  it('eejsBlock_userlist injects the logout button with l10n + ARIA', async function () {
+    const html = await callBlock('eejsBlock_userlist');
+    assert.match(html, /id="ep_hash_auth_logout_btn"/);
+    assert.match(html, /data-l10n-id="ep_hash_auth\.logout"/);
+    assert.match(html, /aria-label=/);
+  });
+
+  it('eejsBlock_scripts injects the client logout script', async function () {
+    const html = await callBlock('eejsBlock_scripts');
+    assert.match(html, /static\/plugins\/ep_hash_auth\/static\/js\/logout\.js/);
+  });
+});

--- a/static/tests/frontend-new/specs/logout.spec.ts
+++ b/static/tests/frontend-new/specs/logout.spec.ts
@@ -1,0 +1,33 @@
+import {expect, test} from '@playwright/test';
+import {goToNewPad} from 'ep_etherpad-lite/tests/frontend-new/helper/padHelper';
+
+// A full login → logout flow needs a hash-authed user fixture written to
+// disk and `settings.ep_hash_auth.hash_dir` pointed at it before the server
+// starts. That setup is brittle in CI, so this spec asserts the UI surface
+// only — the server-side endpoint behavior is covered by the backend tests
+// in static/tests/backend/specs/logout.js.
+
+test.describe('ep_hash_auth logout button', () => {
+  test.beforeEach(async ({page}) => {
+    await goToNewPad(page);
+  });
+
+  test('logout button is rendered in the userlist', async ({page}) => {
+    // Open the userlist popup so the button is in the visible DOM tree.
+    await page.locator('[data-key="showusers"] > a').click();
+    const btn = page.locator('#ep_hash_auth_logout_btn');
+    await expect(btn).toBeVisible();
+    await expect(btn).toHaveAttribute('aria-label', /log out/i);
+    await expect(btn).toHaveAttribute('data-l10n-id', 'ep_hash_auth.logout');
+  });
+
+  test('clicking logout navigates to /', async ({page}) => {
+    await page.locator('[data-key="showusers"] > a').click();
+    // The poison fetch returns 401 but our handler redirects unconditionally.
+    await Promise.all([
+      page.waitForURL((url) => url.pathname === '/'),
+      page.locator('#ep_hash_auth_logout_btn').click(),
+    ]);
+    expect(new URL(page.url()).pathname).toBe('/');
+  });
+});


### PR DESCRIPTION
Closes #50.

## Summary
- Adds a **Log out** button to the pad userlist popup, plus a server `/ep_hash_auth/logout` endpoint.
- Logging out of HTTP Basic is a browser-quirks problem — destroying `req.session.user` is necessary but not sufficient because the browser keeps re-sending the cached `Authorization` header. So this PR does both halves of the cross-browser dance:
  - **Server**: returns 401 with a fresh per-request `WWW-Authenticate` realm to nudge Firefox/Safari to drop their cred cache.
  - **Client**: fetches `/ep_hash_auth/logout` with a deliberately invalid Authorization header to overwrite Chrome's cred cache, then redirects to `/`.
- i18n via `locales/en.json` (`ep_hash_auth.logout`), ARIA label on the button.
- **9 new tests**: 7 backend mocha (endpoint status, realm header, session clearing, no-session safety, eejs block injection) + 2 Playwright (button visible in userlist, click navigates to `/`).

semver: **minor**

## Test plan
- [x] `mocha …/static/tests/backend/specs/logout.js` — 7/7 passing (~180ms)
- [x] `playwright test …/logout.spec.ts --project=chromium` — 2/2 passing (~5s)
- [x] Manual: `curl -i http://localhost:9001/ep_hash_auth/logout` returns 401 + `WWW-Authenticate: Basic realm="ep_hash_auth-logout-…"` + HTML body with a link to `/`
- [x] Lint: no new errors vs baseline (3 pre-existing errors in `no_scrypt.js` / max-len in `ep_hash_auth.js` left untouched)
- [ ] Manual smoke against a hash-authed user (locally installed plugin available — see comment for instructions)

## Notes
- This PR is independent of #103 (test coverage + `.adm` newline fix). Both can land in either order.
- The `data-l10n-id` lets the locale layer translate the label; ARIA `aria-label` ensures screenreaders read "Log out of this Etherpad session" even if l10n hasn't applied yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)